### PR TITLE
index creation for metadata rags

### DIFF
--- a/library/aggrag/ragstore/meta_lang.py
+++ b/library/aggrag/ragstore/meta_lang.py
@@ -27,9 +27,7 @@ import logging
 import os
 
 from llama_index.llms.azure_openai import AzureOpenAI
-from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
-from llama_index.core import VectorStoreIndex, SimpleDirectoryReader, StorageContext, load_index_from_storage
-from llama_index.core.settings import Settings
+from llama_index.core.schema import TextNode
 from llama_index.core.node_parser import HTMLNodeParser
 from langchain_core.documents import Document
 
@@ -209,7 +207,13 @@ class MetaLang:
 
             index = VectorStoreIndex(all_nodes, embed_model=self.embed_model, show_progress=True)
         else:
-            pass
+            
+            dummy_node = TextNode(text="this is a dummy node")
+            index = VectorStoreIndex(nodes=[dummy_node], embed_model=self.embed_model, show_progress=True)
+            # index = VectorStoreIndex(nodes=[BaseNode]) # empty index for placeholder
+
+        os.makedirs(os.path.dirname(persistent_path), exist_ok=True)  
+        index.storage_context.persist(persist_dir=persistent_path)
 
         return index
 

--- a/library/aggrag/ragstore/meta_llama.py
+++ b/library/aggrag/ragstore/meta_llama.py
@@ -22,8 +22,7 @@ import logging
 import os
 import json
 
-from llama_index.llms.azure_openai import AzureOpenAI
-from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
+from llama_index.core.schema import TextNode
 from llama_index.core import VectorStoreIndex, SimpleDirectoryReader
 from llama_index.core.node_parser import HTMLNodeParser
 from llama_index.core.ingestion import IngestionPipeline
@@ -176,6 +175,7 @@ class MetaLlama:
         Returns:
             VectorStoreIndex: The created index object containing the document vectors.
         """
+        persistent_path = os.path.join(self.PERSIST_DIR, self.index_name)
         index = None
         if not documents:
             documents = self.documents
@@ -206,13 +206,11 @@ class MetaLlama:
 
             index = VectorStoreIndex(all_nodes, embed_model=self.embed_model, show_progress=True)
         else:
-            pass
-        #     index = VectorStoreIndex.from_documents(documents, 
-        #                                             embed_model=self.embed_model,
-        #                                             show_progress=True, #use_async=True
-        #                                             )
-        # os.makedirs(os.path.dirname(persistent_path), exist_ok=True)  
-        # index.storage_context.persist(persist_dir=persistent_path)
+            dummy_node = TextNode(text="this is a dummy node")
+            index = VectorStoreIndex(nodes=[dummy_node], embed_model=self.embed_model, show_progress=True)
+        
+        os.makedirs(os.path.dirname(persistent_path), exist_ok=True)  
+        index.storage_context.persist(persist_dir=persistent_path)
 
         return index
 

--- a/library/react-server/src/LLMListComponent.tsx
+++ b/library/react-server/src/LLMListComponent.tsx
@@ -470,7 +470,7 @@ export const LLMListContainer = forwardRef<
             <div className="info-circle">
               <IconInfoCircle size={18} />
             </div>
-            <p>Configuring an LLM is a two step process:</p>
+            <p>Configuring an LLM is a three-step process:</p>
           </div>
         </div>
         <div className="tooltip-description">
@@ -485,6 +485,7 @@ export const LLMListContainer = forwardRef<
             <li>
               Add or connect prompts and variables as required by your use case.
             </li>
+            <p>Note: LLMs don't accept the content from <i>Knowledge Base</i> nodes.</p>
           </ol>
         </div>
       </div>

--- a/library/react-server/src/store.tsx
+++ b/library/react-server/src/store.tsx
@@ -322,6 +322,37 @@ export const initRAGProviderMenu: LLMSpec[] = [
     model: "meta_llama",
     base_model: "meta_llama",
     temp: 0.1,
+    description: (
+      <>
+        The Meta Llama 📚 is a metadata extraction wizard! 🧙‍♂️ It can parse{" "}
+        <br />
+        through documents in various formats (PDFs, HTMLs, and more) and{" "}
+        <br />
+        extract key metadata based on your custom schema. 🔑
+        <br />
+        <br />
+        Simply provide your desired metadata schema, and the Meta Llama will{" "}
+        <br />
+        diligently scour the documents, extracting the relevant information{" "}
+        <br />
+        and presenting it in a structured format. 📂 It's like having a{" "}
+        <br />
+        personal librarian who can quickly find and organize the most{" "}
+        <br />
+        important details for you!
+        <br />
+        <br />
+        <i>
+          Pro tip: Use the Meta Llama when you need to extract specific{" "}
+          <br />
+          information from a large collection of documents, like product{" "}
+          <br />
+          details, legal clauses, or research findings. It'll save you hours{" "}
+          <br />
+          of manual sifting and sorting! 🕰️
+        </i>
+      </>
+    ),
   },
   {
     name: "Meta_lang",
@@ -329,6 +360,37 @@ export const initRAGProviderMenu: LLMSpec[] = [
     model: "meta_lang",
     base_model: "meta_lang",
     temp: 0.1,
+    description: (
+      <>
+        The Meta Lang 📚 is a versatile document wizard! 🧙‍♂️ It can parse{" "}
+        <br />
+        through documents in various formats (PDFs, HTMLs, and more) and{" "}
+        <br />
+        extract key information based on your queries. 🔍
+        <br />
+        <br />
+        Simply ask a question, and the Meta Lang will diligently search{" "}
+        <br />
+        through the documents, retrieving the most relevant information{" "}
+        <br />
+        and presenting it in a concise response. 💬 It's like having a{" "}
+        <br />
+        personal research assistant who can quickly find and synthesize{" "}
+        <br />
+        the details you need!
+        <br />
+        <br />
+        <i>
+          Pro tip: Use the Meta Lang when you need to find specific{" "}
+          <br />
+          information buried within a large collection of documents, like{" "}
+          <br />
+          technical specifications, research papers, or legal contracts.{" "}
+          <br />
+          It'll save you hours of manual searching and reading! ⏱️
+        </i>
+      </>
+    ),
   },
   {
     name: "Table Base",
@@ -336,6 +398,39 @@ export const initRAGProviderMenu: LLMSpec[] = [
     model: "tableBase",
     base_model: "tableBase",
     temp: 0.7,
+    description: (
+      <>
+        The Table Base 📊 is an experimental RAG designed to extract and{" "}
+        <br />
+        process tabular data from PDF documents. 🗄️ It leverages powerful{" "}
+        <br />
+        libraries like Camelot and Tabula to identify and parse tables{" "}
+        <br />
+        within PDFs, transforming them into structured data formats.
+        <br />
+        <br />
+        With the Table Base, you can unlock insights hidden within{" "}
+        <br />
+        complex tables, enabling you to analyze and manipulate the data{" "}
+        <br />
+        with ease. 📈 Whether you need to extract financial reports,{" "}
+        <br />
+        scientific data, or any other tabular information, this RAG has{" "}
+        <br />
+        you covered.
+        <br />
+        <br />
+        <i>
+          Pro tip: Use the Table Base when you need to extract and{" "}
+          <br />
+          process tabular data from a collection of PDF documents. It'll{" "}
+          <br />
+          save you countless hours of manual data entry and formatting,{" "}
+          <br />
+          allowing you to focus on the analysis and insights! ⏱️
+        </i>
+      </>
+    ),
   },
 ];
 


### PR DESCRIPTION
1. index creation for meta-data rags as they were causing error in the UI flow. More specifically, the RagStoreChat api requires an index to be created, but meta llama and meta lang did not create any index as they didn't need them. Now index with dummy node is being generated. 

2. Added descriptions for meta lang, meta lama, and table base rags. 

<img width="646" alt="Screenshot 2024-09-07 at 3 35 10 PM" src="https://github.com/user-attachments/assets/7c7237a2-d609-4e0e-8c2a-82d0de2c58d2">
<img width="622" alt="Screenshot 2024-09-07 at 3 35 15 PM" src="https://github.com/user-attachments/assets/ec0061f6-6242-4d42-bcae-71a851b00b55">
<img width="608" alt="Screenshot 2024-09-07 at 3 35 20 PM" src="https://github.com/user-attachments/assets/b80be35f-e08f-4b71-b24f-fb313034924c">
